### PR TITLE
CsvWriter optionally ommit unneeded comma at the end of every line

### DIFF
--- a/Source/CsvUtility.cs
+++ b/Source/CsvUtility.cs
@@ -27,7 +27,7 @@ public static class CsvUtility
 		? WrapQuotes(value)
 		: value;
 
-	public static string ExportValue(object? value, bool forceQuotes = false)
+	public static string ExportValue(object? value, bool forceQuotes = false, bool lastElement = false)
 	{
 		if (value is null) return ",";
 		var v = value switch
@@ -38,6 +38,6 @@ public static class CsvUtility
 			_ => value.ToString(),
 		};
 
-		return $"{FormatValue(v!, forceQuotes)},";
+		return $"{FormatValue(v!, forceQuotes)}{(lastElement?"":",")}";
 	}
 }

--- a/Source/CsvWriter.cs
+++ b/Source/CsvWriter.cs
@@ -18,64 +18,84 @@ public class CsvWriter : IDisposable
 
 	public void Dispose() => _target = null; // The intention here is if this object is disposed, then prevent further writing.
 
-	public void WriteRow<T>(IEnumerable<T> row, bool forceQuotes = false)
-		=> WriteRow(Target, row, forceQuotes);
+	public void WriteRow<T>(IEnumerable<T> row, bool forceQuotes = false, bool omitLastComma = false)
+		=> WriteRow(Target, row, forceQuotes, omitLastComma);
 
-	public void WriteRows<T>(IEnumerable<IEnumerable<T>> rows, bool forceQuotes = false)
-		=> WriteRows(Target, rows, forceQuotes);
+	public void WriteRows<T>(IEnumerable<IEnumerable<T>> rows, bool forceQuotes = false, bool omitLastComma = false)
+		=> WriteRows(Target, rows, forceQuotes, omitLastComma);
 
-	public static void WriteValue(TextWriter writer, object? value = null, bool forceQuotes = false)
+	public static void WriteValue(TextWriter writer, object? value = null, bool forceQuotes = false, bool lastElement = false)
 	{
 		if (writer is null) throw new ArgumentNullException(nameof(writer));
 		Contract.EndContractBlock();
 
-		writer.Write(CsvUtility.ExportValue(value, forceQuotes));
+		writer.Write(CsvUtility.ExportValue(value, forceQuotes, lastElement));
 	}
 
-	public static Task WriteValueAsync(TextWriter writer, object? value = null, bool forceQuotes = false)
+	public static Task WriteValueAsync(TextWriter writer, object? value = null, bool forceQuotes = false, bool lastElement = false)
 	{
 		if (writer is null) throw new ArgumentNullException(nameof(writer));
 		Contract.EndContractBlock();
 
-		return writer.WriteAsync(CsvUtility.ExportValue(value, forceQuotes));
+		return writer.WriteAsync(CsvUtility.ExportValue(value, forceQuotes, lastElement));
 	}
 
-	public static void WriteRow<T>(TextWriter writer, IEnumerable<T> row, bool forceQuotes = false)
+	public static void WriteRow<T>(TextWriter writer, IEnumerable<T> row, bool forceQuotes = false, bool omitLastComma = false)
 	{
 		if (writer is null) throw new ArgumentNullException(nameof(writer));
 		if (row is null) throw new ArgumentNullException(nameof(row));
 		Contract.EndContractBlock();
 
+		T last = default(T);
+		bool firstElem = true;
 		foreach (var o in row)
-			WriteValue(writer, o, forceQuotes);
+		{
+			if (!firstElem)
+				WriteValue(writer, last, forceQuotes);
+			else
+				firstElem = false;
+
+			last = o;
+		}
+		WriteValue(writer, last, forceQuotes, omitLastComma);
 
 		writer.Write(CsvUtility.NEWLINE);
 	}
 
-	public static async ValueTask WriteRowAsync<T>(TextWriter writer, IEnumerable<T> row, bool forceQuotes = false)
+	public static async ValueTask WriteRowAsync<T>(TextWriter writer, IEnumerable<T> row, bool forceQuotes = false, bool omitLastComma = false)
 	{
 		if (writer is null) throw new ArgumentNullException(nameof(writer));
 		if (row is null) throw new ArgumentNullException(nameof(row));
 		Contract.EndContractBlock();
 
+		T last = default(T);
+		bool firstElem = true;
 		foreach (var o in row)
-			await WriteValueAsync(writer, o, forceQuotes).ConfigureAwait(false);
+		{ 
+			if (!firstElem)
+				await WriteValueAsync(writer, o, forceQuotes).ConfigureAwait(false);
+			else
+				firstElem = false;
+
+			last = o;
+		}
+		await WriteValueAsync(writer, last, forceQuotes, omitLastComma).ConfigureAwait(false);
 
 		await writer.WriteAsync(CsvUtility.NEWLINE).ConfigureAwait(false);
 	}
 
-	public static void WriteRows<T>(TextWriter writer, IEnumerable<IEnumerable<T>> rows, bool forceQuotes = false)
+	public static void WriteRows<T>(TextWriter writer, IEnumerable<IEnumerable<T>> rows, bool forceQuotes = false, bool omitLastComma = false)
 	{
 		if (writer is null) throw new ArgumentNullException(nameof(writer));
 		if (rows is null) throw new ArgumentNullException(nameof(rows));
 		Contract.EndContractBlock();
 
 		foreach (var row in rows)
-			WriteRow(writer, row, forceQuotes);
+			WriteRow(writer, row, forceQuotes, omitLastComma);
 	}
 
 #if NETSTANDARD2_1_OR_GREATER
-		public static async ValueTask WriteRowsAsync<T>(TextWriter writer, IAsyncEnumerable<IEnumerable<T>> rows, bool forceQuotes = false)
+		public static async ValueTask WriteRowsAsync<T>(TextWriter writer, IAsyncEnumerable<IEnumerable<T>> rows, bool forceQuotes = false, bool omitLastComma = false)
 		{
 			if (writer is null) throw new ArgumentNullException(nameof(writer));
 			if (rows is null) throw new ArgumentNullException(nameof(rows));
@@ -86,7 +106,7 @@ public class CsvWriter : IDisposable
 			await foreach (var row in rows)
 			{
 				await next.ConfigureAwait(false);
-				next = WriteRowAsync(writer, row, forceQuotes);
+				next = WriteRowAsync(writer, row, forceQuotes, omitLastComma);
 			}
 
 			await next.ConfigureAwait(false);

--- a/Tests/CsvWriterTests.cs
+++ b/Tests/CsvWriterTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace Open.Text.CSV.Test;
+
+public static class CsvWriterTests
+{
+	[Fact]
+	public static void CsvWriter_BasicRowBuildTest()
+	{
+		MemoryStream ms = new MemoryStream();
+		TextWriter tw = new StreamWriter(ms);
+		string[] fields = { "Field1", "with_\"Doublequotes\"", "", "with_comma,", "with_doublequoted_comma\",\"", "" };
+		CsvWriter csw = new CsvWriter(tw);
+
+		csw.WriteRow(fields);
+		tw.Flush();
+		byte[] buff = new byte[ms.Length];
+		Array.Copy(ms.GetBuffer(), buff, ms.Length);
+		string line_without_quotes = Encoding.UTF8.GetString(buff);
+		Assert.Equal(line_without_quotes, "Field1,with_\"Doublequotes\",,\"with_comma,\",\"with_doublequoted_comma\"\",\"\"\",,\r\n");
+
+		ms.SetLength(0);
+		csw.WriteRow(fields, omitLastComma:true);
+		tw.Flush();
+		buff = new byte[ms.Length];
+		Array.Copy(ms.GetBuffer(), buff, ms.Length);
+		string line_without_quotes_without_comma_at_end = Encoding.UTF8.GetString(buff);
+		Assert.Equal(line_without_quotes_without_comma_at_end, "Field1,with_\"Doublequotes\",,\"with_comma,\",\"with_doublequoted_comma\"\",\"\"\",\r\n");
+
+		ms.SetLength(0);
+		csw.WriteRow(fields, true);
+		tw.Flush();
+		buff = new byte[ms.Length];
+		Array.Copy(ms.GetBuffer(), buff, ms.Length);
+		string line_with_quotes = Encoding.UTF8.GetString(buff);
+		Assert.Equal(line_with_quotes, "\"Field1\",\"with_\"\"Doublequotes\"\"\",,\"with_comma,\",\"with_doublequoted_comma\"\",\"\"\",,\r\n");
+
+
+		ms.SetLength(0);
+		csw.WriteRow(fields, true, true);
+		tw.Flush();
+		buff = new byte[ms.Length];
+		Array.Copy(ms.GetBuffer(), buff, ms.Length);
+		string line_with_quotes_without_comma_at_end = Encoding.UTF8.GetString(buff);
+		Assert.Equal(line_with_quotes_without_comma_at_end, "\"Field1\",\"with_\"\"Doublequotes\"\"\",,\"with_comma,\",\"with_doublequoted_comma\"\",\"\"\",\r\n");
+
+
+	}
+}


### PR DESCRIPTION
Using CsvWriter added an empty column because to every value field always a comma was appended, also for the last column value. To avoid breaking changes, I added the parameter omitLastComma to CsvWriter.WriteRow function family.